### PR TITLE
Add `no_auth` option: pre-release fork

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -39,6 +39,26 @@ jobs:
       - name: Verify log-in
         run: doctl compute region list
 
+  test_no_auth:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Install doctl
+        uses: ./
+        with:
+          no_auth: true
+
+      - name: Verify installation
+        run: doctl version
+
+      - name: Verify not authenticated
+        run: |
+          doctl compute region list 2>&1 | grep -qi "Unable to initialize DigitalOcean API client: access token is required"
+
   test_custom_version_linux_and_mac:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -71,12 +71,14 @@ jobs:
         uses: ./
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
-          version: 1.38.0
+          version: v1.101.0-pre.git.f747827eb8e6
 
       - name: Verify installation of correct version
         run: |
           VERSION=$(doctl version | head -1 | cut -f3 -d' ' | cut -f1 -d'-')
-          if [ "$VERSION" != "1.38.0" ]; then exit 1; fi
+          if [ "$VERSION" != "1.101.0" ]; then exit 1; fi
+          GIT_SHA=$(doctl version | grep -i 'Git commit' | cut -f2 -d':' | tr -d ' \n')
+          if [ "$GIT_SHA" != "f747827e" ]; then exit 1; fi
 
       - name: Verify log-in
         run: doctl compute region list
@@ -90,12 +92,14 @@ jobs:
         uses: ./
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
-          version: 1.38.0
+          version: v1.101.0-pre.git.f747827eb8e6
 
       - name: Verify installation of correct version
         run: |
           $VERSION = (doctl version | head -1 | cut -f3 -d' ' | cut -f1 -d'-')
-          If (-NOT  ($VERSION -eq "1.38.0")) { exit 1 }
+          If (-NOT  ($VERSION -eq "1.101.0")) { exit 1 }
+          $GIT_SHA = (doctl version | grep -i 'Git commit' | cut -f2 -d':' | tr -d ' \n')
+          If (-NOT  ($GIT_SHA -eq "f747827e")) { exit 1 }
 
       - name: Verify log-in
         run: doctl compute region list

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ See [this repository](https://github.com/do-community/example-doctl-action) for 
 
 - `token` – (**Required**) A DigitalOcean personal access token ([more info](https://docs.digitalocean.com/reference/api/create-personal-access-token/)).
 - `version` – (Optional) The version of `doctl` to install. If excluded, the latest release will be used.
+- `no_auth` – (Optional) Set to `true` to skip the authentication step. The API `token` parameter is _Optional_ in this case.
+  - _Note:_ This can be useful when running in workflows in untrusted environments, or where auth isn't necessary (e.g. `doctl app spec validate`)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ See [this repository](https://github.com/do-community/example-doctl-action) for 
 - `token` – (**Required**) A DigitalOcean personal access token ([more info](https://docs.digitalocean.com/reference/api/create-personal-access-token/)).
 - `version` – (Optional) The version of `doctl` to install. If excluded, the latest release will be used.
 - `no_auth` – (Optional) Set to `true` to skip the authentication step. The API `token` parameter is _Optional_ in this case.
-  - _Note:_ This can be useful when running in workflows in untrusted environments, or where auth isn't necessary (e.g. `doctl app spec validate`)
+  - _Note:_ This can be useful when running in workflows in untrusted environments, or where auth isn't necessary (e.g. `doctl app spec validate-offline`)
 
 ## Contributing
 

--- a/action.yml
+++ b/action.yml
@@ -8,9 +8,12 @@ inputs:
   version:
     description: 'Version of doctl to install'
     default: 'latest'
+  no_auth:
+    description: 'Skip authentication'
+    default: 'false'
   token:
     description: 'DigitalOcean API Token'
-    required: true
+    default: ''
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -17538,6 +17538,14 @@ Failed to retrieve latest version; falling back to: ${fallbackVersion}`);
     core.addPath(path);
     core.info(`>>> doctl version v${version} installed to ${path}`);
 
+    // Skip authentication if requested
+    // for workflows where auth isn't necessary (e.g. doctl app spec validate)
+    var no_auth = core.getInput('no_auth');
+    if (no_auth.toLowerCase() === 'true') {
+      core.info('>>> Skipping doctl auth');
+      return;
+    }
+
     var token = core.getInput('token', { required: true });
     core.setSecret(token);
     await exec.exec('doctl auth init -t', [token]);

--- a/dist/index.js
+++ b/dist/index.js
@@ -17539,7 +17539,7 @@ Failed to retrieve latest version; falling back to: ${fallbackVersion}`);
     core.info(`>>> doctl version v${version} installed to ${path}`);
 
     // Skip authentication if requested
-    // for workflows where auth isn't necessary (e.g. doctl app spec validate)
+    // for workflows where auth isn't necessary (e.g. doctl app spec validate-offline)
     var no_auth = core.getInput('no_auth');
     if (no_auth.toLowerCase() === 'true') {
       core.info('>>> Skipping doctl auth');

--- a/dist/index.js
+++ b/dist/index.js
@@ -17460,8 +17460,8 @@ const exec = __nccwpck_require__(1514);
 const tc = __nccwpck_require__(7784);
 const { Octokit } = __nccwpck_require__(5375);
 
-const baseDownloadURL = "https://github.com/digitalocean/doctl/releases/download";
-const fallbackVersion = "1.98.1";
+const baseDownloadURL = "https://github.com/trinitronx/doctl/releases/download";
+const fallbackVersion = "1.101.0-pre.git.f747827eb8e6";
 const octokit = new Octokit();
 
 async function downloadDoctl(version, type, architecture) {
@@ -17512,7 +17512,7 @@ async function run() {
     var version = core.getInput('version');
     if ((!version) || (version.toLowerCase() === 'latest')) {
         version = await octokit.repos.getLatestRelease({
-            owner: 'digitalocean',
+            owner: 'trinitronx',
             repo: 'doctl'
         }).then(result => {
             return result.data.name;

--- a/main.js
+++ b/main.js
@@ -81,6 +81,14 @@ Failed to retrieve latest version; falling back to: ${fallbackVersion}`);
     core.addPath(path);
     core.info(`>>> doctl version v${version} installed to ${path}`);
 
+    // Skip authentication if requested
+    // for workflows where auth isn't necessary (e.g. doctl app spec validate)
+    var no_auth = core.getInput('no_auth');
+    if (no_auth.toLowerCase() === 'true') {
+      core.info('>>> Skipping doctl auth');
+      return;
+    }
+
     var token = core.getInput('token', { required: true });
     core.setSecret(token);
     await exec.exec('doctl auth init -t', [token]);

--- a/main.js
+++ b/main.js
@@ -82,7 +82,7 @@ Failed to retrieve latest version; falling back to: ${fallbackVersion}`);
     core.info(`>>> doctl version v${version} installed to ${path}`);
 
     // Skip authentication if requested
-    // for workflows where auth isn't necessary (e.g. doctl app spec validate)
+    // for workflows where auth isn't necessary (e.g. doctl app spec validate-offline)
     var no_auth = core.getInput('no_auth');
     if (no_auth.toLowerCase() === 'true') {
       core.info('>>> Skipping doctl auth');

--- a/main.js
+++ b/main.js
@@ -4,7 +4,7 @@ const tc = require('@actions/tool-cache');
 const { Octokit } = require("@octokit/rest");
 
 const baseDownloadURL = "https://github.com/trinitronx/doctl/releases/download";
-const fallbackVersion = "1.101.0-pre.git.69cd972159a0";
+const fallbackVersion = "1.101.0-pre.git.f747827eb8e6";
 const octokit = new Octokit();
 
 async function downloadDoctl(version, type, architecture) {
@@ -55,7 +55,7 @@ async function run() {
     var version = core.getInput('version');
     if ((!version) || (version.toLowerCase() === 'latest')) {
         version = await octokit.repos.getLatestRelease({
-            owner: 'digitalocean',
+            owner: 'trinitronx',
             repo: 'doctl'
         }).then(result => {
             return result.data.name;

--- a/main.js
+++ b/main.js
@@ -3,8 +3,8 @@ const exec = require('@actions/exec');
 const tc = require('@actions/tool-cache');
 const { Octokit } = require("@octokit/rest");
 
-const baseDownloadURL = "https://github.com/digitalocean/doctl/releases/download";
-const fallbackVersion = "1.98.1";
+const baseDownloadURL = "https://github.com/trinitronx/doctl/releases/download";
+const fallbackVersion = "1.101.0-pre.git.69cd972159a0";
 const octokit = new Octokit();
 
 async function downloadDoctl(version, type, architecture) {


### PR DESCRIPTION
Testing CI workflow with new [pre-release `doctl`][1]

- Ensured GitHub Actions cache is clean
- Fixed `repo` / `owner` slugs
- Re-ran `npm run package` to regenerate `dist/index.js`


[1]: https://github.com/trinitronx/doctl/releases/tag/v1.101.0-pre.git.f747827eb8e6